### PR TITLE
dart sdk issue fix

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ description: "Demonstrates how to use the equal_sdk_flutter plugin."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.5.4
+  sdk: ^3.5.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage:
 
 environment:
-  sdk: ^3.5.4
+  sdk: ^3.5.0
   flutter: '>=3.3.0'
 
 dependencies:


### PR DESCRIPTION
The current Flutter SDK is compatible with the latest Flutter version (3.27.0). However, since one of our clients has not yet migrated to the latest version, we have added backward compatibility. The current changes ensure the Flutter SDK will work with versions above **Flutter 3.24.0 and Dart 3.5.0.**