### PR TITLE
Fix exit dialog button colors

### DIFF
--- a/lib/view/equal_in_app_web_view_helper.dart
+++ b/lib/view/equal_in_app_web_view_helper.dart
@@ -52,10 +52,16 @@ class EqualInAppWebViewWidget extends IWebView {
         content: const Text('Are you sure you want to exit?'),
         actions: [
           TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.onSurface,
+            ),
             child: const Text('No'),
             onPressed: () => Navigator.of(context).pop(),
           ),
           TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.onSurface,
+            ),
             child: const Text('Yes'),
             onPressed: () {
               onError.call(


### PR DESCRIPTION
## Issue:
![IMG_8398](https://github.com/user-attachments/assets/be5d0b0f-e3e1-4f84-adfc-a6acfc1fd081)

client: WeWork

## Summary
- improve exit dialog visibility in dark themes by styling buttons with the current `onSurface` color

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_b_683f9e0adb54832aadd5697cd182bf1d